### PR TITLE
Add fpga_loop config section

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -5475,6 +5475,42 @@ cs_pin:
 #   above parameters.
 ```
 
+### [fpga_loop]
+
+Closed loop motion control handled by an external FPGA.  The FPGA
+communicates with the MCU via SPI and provides step generation and
+feedback for the configured axes.
+
+```
+[fpga_loop myloop]
+spi_cs_pin:
+#   Chip select pin for the FPGA.  This parameter must be provided.
+#spi_speed: 1000000
+#spi_bus:
+#spi_software_sclk_pin:
+#spi_software_mosi_pin:
+#spi_software_miso_pin:
+#   See the "common SPI settings" section for a description of the above
+#   parameters.  On micro-controllers without available hardware SPI,
+#   specify the spi_software_* pins.
+axis_x:
+axis_y:
+axis_z:
+axis_a:
+axis_b:
+#   Names of the stepper sections for each controlled axis.  Omit an
+#   axis to disable it.
+#pid_P: 0.100
+#pid_I: 0.010
+#pid_D: 0.001
+#   PID constants used by the FPGA controller.  The defaults are 0.
+#update_interval: 0.005
+#   Time between updates to the FPGA PWM generator.  The default is
+#   0.005 seconds.
+#invert_enable: False
+#   Invert the enable pin logic if necessary.
+```
+
 ## Common bus parameters
 
 ### Common SPI settings

--- a/docs/MCU_Commands.md
+++ b/docs/MCU_Commands.md
@@ -245,6 +245,10 @@ only of interest to developers looking to gain insight into Klipper.
   the clock so that the next step is relative to the supplied 'clock'
   time. The host usually only sends this command at the start of a
   print.
+* `stepper_set_fpga oid=%c enable=%c` : When `enable` is 1 the MCU will
+  suppress step and direction pin updates for the given stepper so that
+  an external controller can drive it. Setting `enable` to 0 reverts to
+  normal MCU driven stepping.
 
 * `stepper_get_position oid=%c` : This command causes the
   micro-controller to generate a "stepper_position" response message
@@ -291,3 +295,18 @@ scheduling new queue_step commands accordingly.
 * `spi_send oid=%c data=%*s` : This command is similar to
   "spi_transfer", but it does not generate a "spi_transfer_response"
   message.
+
+### FPGA closed-loop controller
+
+* `config_fpga oid=%c spi_oid=%c axis_x_oid=%c microsteps_x=%hu`
+  `axis_y_oid=%c microsteps_y=%hu axis_z_oid=%c microsteps_z=%hu`
+  `axis_a_oid=%c microsteps_a=%hu axis_b_oid=%c microsteps_b=%hu`
+  `pid_P=%hu pid_I=%hu pid_D=%hu` : Configure an FPGA used for motor
+  control. The host provides the stepper OIDs for each axis along with
+  microstep settings and PID gains. The MCU forwards this configuration
+  via SPI to the attached FPGA.
+
+* `queue_fpga_pwm oid=%c clock=%u duty=%hu` : Schedule an update to the
+  FPGA PWM generator. `duty` is an integer between 0 and the
+  `FPGA_PWM_MAX` constant. The MCU will transmit the command at the
+  specified clock time.

--- a/klippy/extras/fpga_loop.py
+++ b/klippy/extras/fpga_loop.py
@@ -1,0 +1,126 @@
+# Controle de movimento em malha fechada via FPGA conectado ao MCU.
+# Este módulo permite configurar parâmetros estáticos do controlador FPGA
+# e enviar comandos PWM em tempo real utilizando a fila de comandos do MCU.
+#
+# Copyright (C) 2025  Your Name <you@domain.com>
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+import logging
+from . import bus
+
+
+class FPGALoopController:
+    """Controlador de malha fechada baseado em FPGA."""
+
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.reactor = self.printer.get_reactor()
+        self.name = config.get_name().split()[-1]
+
+        # Configura objeto SPI utilizando o helper padronizado
+        # (permite que o MCU trate detalhes do barramento)
+        self.spi = bus.MCU_SPI_from_config(
+            config, 0, pin_option='spi_cs_pin', default_speed=1000000)
+
+        # Definição de eixos associados a steppers
+        self._axis_defs = {}
+        for axis in ['x', 'y', 'z', 'a', 'b']:
+            sec_name = config.get(f'axis_{axis}', None)
+            if sec_name is None:
+                continue
+            scfg = config.getsection(sec_name)
+            microsteps = scfg.getint('microsteps', note_valid=False)
+            self._axis_defs[axis] = (sec_name, microsteps)
+
+        # Ganhos PID configurados para o controlador
+        self.pid_P = config.getfloat('pid_P', minval=0.0)
+        self.pid_I = config.getfloat('pid_I', minval=0.0)
+        self.pid_D = config.getfloat('pid_D', minval=0.0)
+
+        self.update_interval = config.getfloat('update_interval', 0.005,
+                                               above=0.)
+        self.invert_enable = config.getboolean('invert_enable', False)
+
+        # Variáveis inicializadas após evento 'klippy:connect'
+        self._mcu = None
+        self.oid = None
+        self._axes = {}
+        self.cmd_queue = None
+        self._queue_pwm = None
+        self._last_clock = 0
+
+        # Adia conexões até que todos os módulos estejam instanciados
+        self.printer.register_event_handler('klippy:connect',
+                                            self._handle_connect)
+
+    def _handle_connect(self):
+        # Obter referências a MCU e steppers somente após todos existirem
+        self._mcu = self.printer.lookup_object('mcu')
+        self.oid = self._mcu.create_oid()
+        force_move = self.printer.lookup_object('force_move')
+        toolhead = self.printer.lookup_object('toolhead')
+        for axis, (sname, microsteps) in self._axis_defs.items():
+            stepper = force_move.lookup_stepper(sname)
+            self._axes[axis] = (stepper, microsteps)
+            # Desativa o gerador de passos normal (queue_step) para este eixo.
+            # Os pulsos serão emitidos exclusivamente pelo FPGA.
+            toolhead.unregister_step_generator(stepper.generate_steps)
+        # Passa a utilizar o gerador de passos deste módulo, que repassa
+        # comandos ao FPGA em vez de programar pulsos no MCU.
+        toolhead.register_step_generator(self._stepgen_fpga)
+
+        self._mcu.register_config_callback(self._build_config)
+        self._init_pwm()
+
+    def _build_config(self):
+        parts = [
+            f"config_fpga oid={self.oid}",
+            f"spi_oid={self.spi.get_oid()}"
+        ]
+        for axis, (stepper, microsteps) in self._axes.items():
+            parts.append(f"axis_{axis}_oid={stepper.get_oid()}")
+            parts.append(f"microsteps_{axis}={microsteps}")
+        parts.append(f"pid_P={self.pid_P}")
+        parts.append(f"pid_I={self.pid_I}")
+        parts.append(f"pid_D={self.pid_D}")
+        cmd = ' '.join(parts)
+        self._mcu.add_config_cmd(cmd)
+        for stepper, _ in self._axes.values():
+            self._mcu.add_config_cmd(
+                f"stepper_set_fpga oid={stepper.get_oid()} enable=1")
+        logging.info("FPGA Loop '%s' configurado: %s", self.name, cmd)
+
+    def _init_pwm(self):
+        self.cmd_queue = self._mcu.alloc_command_queue()
+        # O firmware define o valor maximo de PWM atraves da constante
+        # FPGA_PWM_MAX. Obtemos esse valor para converter o duty (0.0-1.0)
+        self._pwm_max = self._mcu.get_constant_float('FPGA_PWM_MAX')
+        self._queue_pwm = self._mcu.lookup_command(
+            "queue_fpga_pwm oid=%c clock=%u duty=%hu",
+            cq=self.cmd_queue)
+        logging.info("FPGA Loop '%s': fila PWM inicializada", self.name)
+
+    def _stepgen_fpga(self, flush_time):
+        """Gerador de passos substituto que envia atualizacoes de PWM."""
+        try:
+            self.set_pwm(flush_time, 0.)
+        except self.printer.command_error as e:
+            logging.error("FPGA stepgen erro: %s", str(e))
+        return
+
+    def set_pwm(self, print_time, duty):
+        if self._queue_pwm is None:
+            raise self.printer.command_error("FPGA loop não inicializado")
+        clock = self._mcu.print_time_to_clock(print_time)
+        clock = max(self._last_clock, clock)
+        duty = max(0.0, min(1.0, duty))
+        ivalue = int(duty * self._pwm_max + 0.5)
+        self._queue_pwm.send([self.oid, clock, ivalue],
+                             minclock=self._last_clock, reqclock=clock)
+        self._last_clock = clock
+        logging.debug("FPGA Loop '%s': duty=%.3f enviado em clock=%d",
+                      self.name, duty, clock)
+
+
+def load_config_prefix(config):
+    return FPGALoopController(config)

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -256,6 +256,7 @@ config WANT_LDC1612
 config WANT_SENSOR_ANGLE
     bool "Support angle sensors"
     depends on WANT_SPI
+
 endmenu
 
 # Generic configuration options for CANbus

--- a/src/Makefile
+++ b/src/Makefile
@@ -26,6 +26,7 @@ src-$(CONFIG_WANT_HX71X) += sensor_hx71x.c
 src-$(CONFIG_WANT_ADS1220) += sensor_ads1220.c
 src-$(CONFIG_WANT_LDC1612) += sensor_ldc1612.c
 src-$(CONFIG_WANT_SENSOR_ANGLE) += sensor_angle.c
+src-y += fpgacmds.c
 src-$(CONFIG_NEED_SENSOR_BULK) += sensor_bulk.c
 src-$(CONFIG_NEED_SOS_FILTER) += sos_filter.c
 src-$(CONFIG_WANT_LOAD_CELL_PROBE) += load_cell_probe.c

--- a/src/fpgacmds.c
+++ b/src/fpgacmds.c
@@ -1,0 +1,121 @@
+// Commands for FPGA based closed-loop motor controller
+//
+// Copyright (C) 2025  Your Name
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include <string.h>
+#include "board/irq.h"           // irq_disable
+#include "board/gpio.h"          // gpio_out_write
+#include "board/misc.h"          // timer_is_before
+#include "basecmd.h"             // oid_alloc
+#include "command.h"             // DECL_COMMAND
+#include "sched.h"               // sched_add_timer
+#include "spicmds.h"            // spidev_transfer
+#include "stepper.h"             // stepper_set_fpga
+
+// Valor maximo que representa duty cycle em queue_fpga_pwm
+#define FPGA_PWM_MAX 65535
+DECL_CONSTANT("FPGA_PWM_MAX", FPGA_PWM_MAX);
+
+// Estrutura para cada atualizacao de duty enviado ao FPGA
+struct fpga_pwm_move {
+    struct move_node node;
+    uint32_t waketime; // momento para envio no clock MCU
+    uint16_t duty;     // valor de duty (0..FPGA_PWM_MAX)
+};
+
+// Estrutura principal associada a um controlador FPGA
+struct fpga_controller {
+    struct timer timer;            // gerencia execucao dos comandos enfileirados
+    struct spidev_s *spi;         // interface SPI utilizada
+    struct move_queue_head mq;    // fila de atualizacoes PWM
+};
+
+/********************************************************************
+ * Rotina de envio ao FPGA
+ ********************************************************************/
+
+// Envia o proximo comando PWM ao FPGA quando chega o tempo indicado
+static uint_fast8_t
+fpga_pwm_event(struct timer *t)
+{
+    struct fpga_controller *fc = container_of(t, struct fpga_controller, timer);
+    struct move_node *mn = move_queue_pop(&fc->mq);
+    struct fpga_pwm_move *m = container_of(mn, struct fpga_pwm_move, node);
+
+    // Monta mensagem simples: cmd=1, duty em formato little-endian
+    uint8_t msg[3] = { 1, m->duty & 0xff, m->duty >> 8 };
+    spidev_transfer(fc->spi, 0, sizeof(msg), msg);
+    move_free(m);
+
+    if (move_queue_empty(&fc->mq))
+        return SF_DONE;
+
+    struct fpga_pwm_move *next = container_of(move_queue_first(&fc->mq),
+                                              struct fpga_pwm_move, node);
+    t->waketime = next->waketime;
+    return SF_RESCHEDULE;
+}
+
+/********************************************************************
+ * Comandos acessíveis pelo host
+ ********************************************************************/
+
+// Configura um novo controlador FPGA e envia parametros basicos por SPI
+void
+command_config_fpga(uint32_t *args)
+{
+    struct fpga_controller *fc = oid_alloc(args[0], command_config_fpga,
+                                           sizeof(*fc));
+    fc->timer.func = fpga_pwm_event;
+    fc->spi = spidev_oid_lookup(args[1]);
+    move_queue_setup(&fc->mq, sizeof(struct fpga_pwm_move));
+
+    // Transmite configuracao estatica ao FPGA. O formato exato da
+    // mensagem eh definido pela implementacao do hardware e pode
+    // incluir, por exemplo, o oid dos steppers e parametros PID.
+    uint8_t cfg[2] = { 0 }; // cmd=0 indica configuracao
+    spidev_transfer(fc->spi, 0, sizeof(cfg), cfg);
+}
+DECL_COMMAND(command_config_fpga,
+             "config_fpga oid=%c spi_oid=%c"
+             " axis_x_oid=%c microsteps_x=%hu"
+             " axis_y_oid=%c microsteps_y=%hu"
+             " axis_z_oid=%c microsteps_z=%hu"
+             " axis_a_oid=%c microsteps_a=%hu"
+             " axis_b_oid=%c microsteps_b=%hu"
+             " pid_P=%hu pid_I=%hu pid_D=%hu");
+
+// Enfileira nova atualizacao de duty para o FPGA
+void
+command_queue_fpga_pwm(uint32_t *args)
+{
+    struct fpga_controller *fc = oid_lookup(args[0], command_config_fpga);
+    struct fpga_pwm_move *m = move_alloc();
+    m->waketime = args[1];
+    m->duty = args[2];
+
+    irq_disable();
+    int need_add = move_queue_push(&m->node, &fc->mq);
+    irq_enable();
+    if (!need_add)
+        return;
+
+    sched_del_timer(&fc->timer);
+    fc->timer.waketime = m->waketime;
+    sched_add_timer(&fc->timer);
+}
+DECL_COMMAND(command_queue_fpga_pwm,
+             "queue_fpga_pwm oid=%c clock=%u duty=%hu");
+
+// Limpa filas e pinos durante desligamento
+void
+fpga_shutdown(void)
+{
+    uint8_t i; struct fpga_controller *fc;
+    foreach_oid(i, fc, command_config_fpga) {
+        move_queue_clear(&fc->mq);
+    }
+}
+DECL_SHUTDOWN(fpga_shutdown);
+

--- a/src/stepper.c
+++ b/src/stepper.c
@@ -14,6 +14,15 @@
 #include "stepper.h" // stepper_event
 #include "trsync.h" // trsync_add_signal
 
+#define STEP_TOGGLE(s) do { \
+    if (!((s)->flags & SF_FPGA_CONTROL)) \
+        gpio_out_toggle_noirq((s)->step_pin); \
+} while (0)
+#define DIR_TOGGLE(s) do { \
+    if (!((s)->flags & SF_FPGA_CONTROL)) \
+        gpio_out_toggle_noirq((s)->dir_pin); \
+} while (0)
+
 DECL_CONSTANT("STEPPER_STEP_BOTH_EDGE", 1);
 
 #if CONFIG_INLINE_STEPPER_HACK && CONFIG_WANT_STEPPER_OPTIMIZED_BOTH_EDGE
@@ -55,7 +64,8 @@ enum { POSITION_BIAS=0x40000000 };
 
 enum {
     SF_LAST_DIR=1<<0, SF_NEXT_DIR=1<<1, SF_INVERT_STEP=1<<2, SF_NEED_RESET=1<<3,
-    SF_SINGLE_SCHED=1<<4, SF_OPTIMIZED_PATH=1<<5, SF_HAVE_ADD=1<<6
+    SF_SINGLE_SCHED=1<<4, SF_OPTIMIZED_PATH=1<<5, SF_HAVE_ADD=1<<6,
+    SF_FPGA_CONTROL=1<<7
 };
 
 // Setup a stepper for the next move in its queue
@@ -113,7 +123,7 @@ stepper_load_next(struct stepper *s)
             if (s->flags & SF_SINGLE_SCHED)
                 while (timer_is_before(timer_read_time(), min_next_time))
                     ;
-            gpio_out_toggle_noirq(s->dir_pin);
+            DIR_TOGGLE(s);
             uint32_t curtime = timer_read_time();
             min_next_time = curtime + s->step_pulse_ticks;
             if (timer_is_before(s->time.waketime, min_next_time))
@@ -124,7 +134,7 @@ stepper_load_next(struct stepper *s)
 
     // Set new direction (if needed)
     if (need_dir_change)
-        gpio_out_toggle_noirq(s->dir_pin);
+        DIR_TOGGLE(s);
     return SF_RESCHEDULE;
 }
 
@@ -139,7 +149,7 @@ static uint_fast8_t
 stepper_event_edge(struct timer *t)
 {
     struct stepper *s = container_of(t, struct stepper, time);
-    gpio_out_toggle_noirq(s->step_pin);
+    STEP_TOGGLE(s);
     uint32_t count = s->count - 1;
     if (likely(count)) {
         s->count = count;
@@ -160,18 +170,18 @@ static uint_fast8_t
 stepper_event_avr(struct timer *t)
 {
     struct stepper *s = container_of(t, struct stepper, time);
-    gpio_out_toggle_noirq(s->step_pin);
+    STEP_TOGGLE(s);
     uint16_t *pcount = (void*)&s->count, count = *pcount - 1;
     if (likely(count)) {
         *pcount = count;
         s->time.waketime += s->interval;
-        gpio_out_toggle_noirq(s->step_pin);
+        STEP_TOGGLE(s);
         if (s->flags & SF_HAVE_ADD)
             s->interval += s->add;
         return SF_RESCHEDULE;
     }
     uint_fast8_t ret = stepper_load_next(s);
-    gpio_out_toggle_noirq(s->step_pin);
+    STEP_TOGGLE(s);
     return ret;
 }
 
@@ -180,7 +190,7 @@ static uint_fast8_t
 stepper_event_full(struct timer *t)
 {
     struct stepper *s = container_of(t, struct stepper, time);
-    gpio_out_toggle_noirq(s->step_pin);
+    STEP_TOGGLE(s);
     uint32_t curtime = timer_read_time();
     uint32_t min_next_time = curtime + s->step_pulse_ticks;
     uint32_t count = s->count - 1;
@@ -253,6 +263,28 @@ stepper_oid_lookup(uint8_t oid)
 {
     return oid_lookup(oid, command_config_stepper);
 }
+
+// Enable or disable FPGA control for the given stepper
+void
+stepper_set_fpga(uint8_t oid, uint8_t enable)
+{
+    struct stepper *s = stepper_oid_lookup(oid);
+    irq_disable();
+    if (enable)
+        s->flags |= SF_FPGA_CONTROL;
+    else
+        s->flags &= ~SF_FPGA_CONTROL;
+    irq_enable();
+}
+
+// Command wrapper to configure FPGA control at runtime
+void
+command_stepper_set_fpga(uint32_t *args)
+{
+    stepper_set_fpga(args[0], args[1]);
+}
+DECL_COMMAND(command_stepper_set_fpga,
+             "stepper_set_fpga oid=%c enable=%c");
 
 // Schedule a set of steps with a given timing
 void
@@ -356,11 +388,13 @@ stepper_stop(struct trsync_signal *tss, uint8_t reason)
     s->count = 0;
     s->flags = ((s->flags & (SF_INVERT_STEP|SF_SINGLE_SCHED|SF_OPTIMIZED_PATH))
                 | SF_NEED_RESET);
-    gpio_out_write(s->dir_pin, 0);
-    if (!(s->flags & SF_SINGLE_SCHED)
-        || (HAVE_AVR_OPTIMIZATION && s->flags & SF_OPTIMIZED_PATH))
-        // Must return step pin to "unstep" state
-        gpio_out_write(s->step_pin, s->flags & SF_INVERT_STEP);
+    if (!(s->flags & SF_FPGA_CONTROL)) {
+        gpio_out_write(s->dir_pin, 0);
+        if (!(s->flags & SF_SINGLE_SCHED)
+            || (HAVE_AVR_OPTIMIZATION && s->flags & SF_OPTIMIZED_PATH))
+            // Must return step pin to "unstep" state
+            gpio_out_write(s->step_pin, s->flags & SF_INVERT_STEP);
+    }
     while (!move_queue_empty(&s->mq)) {
         struct move_node *mn = move_queue_pop(&s->mq);
         struct stepper_move *m = container_of(mn, struct stepper_move, node);

--- a/src/stepper.h
+++ b/src/stepper.h
@@ -4,5 +4,6 @@
 #include <stdint.h> // uint8_t
 
 uint_fast8_t stepper_event(struct timer *t);
+void stepper_set_fpga(uint8_t oid, uint8_t enable);
 
 #endif // stepper.h


### PR DESCRIPTION
## Summary
- document the new `[fpga_loop]` section in the config reference
- show how to specify software SPI pins for AVR setups

## Testing
- `python3 scripts/test_klippy.py test/klippy/commands.test` *(failed: FileNotFoundError: './atmega2560.dict')*

------