### PR TITLE
Fix FPGALoop disconnect check

### DIFF
--- a/klippy/extras/fpga_loop.py
+++ b/klippy/extras/fpga_loop.py
@@ -111,7 +111,8 @@ class FPGALoopController:
         toolhead = self.printer.lookup_object('toolhead')
         for stepper, _ in self._axes.values():
             toolhead.register_step_generator(stepper.generate_steps)
-            if self._set_fpga_cmd is not None:
+            if (self._set_fpga_cmd is not None
+                    and self._mcu._serial.get_serialqueue() is not None):
                 self._set_fpga_cmd.send([stepper.get_oid(), 0])
         try:
             toolhead.unregister_step_generator(self._stepgen_fpga)


### PR DESCRIPTION
## Summary
- avoid sending FPGA disable command after MCU disconnect

## Testing
- `scripts/check_whitespace.sh`
- `make test` *(fails: `avr-gcc` not found)*
- `python3 scripts/test_klippy.py test/klippy/commands.test` *(fails: missing './atmega2560.dict')*

------
https://chatgpt.com/codex/tasks/task_e_686300797da483268e7a9d96749f9fd0